### PR TITLE
If always_update config is setup - Then only chef update (which does a chef install)

### DIFF
--- a/lib/kitchen/provisioner/chef/policyfile.rb
+++ b/lib/kitchen/provisioner/chef/policyfile.rb
@@ -69,20 +69,20 @@ module Kitchen
             run_command("#{cli_path} export #{escape_path(policyfile)} #{escape_path(path)} --force --chef-license #{license}")
           end
         end
-
+        
         # Runs `chef install` to determine the correct cookbook set and
         # generate the policyfile lock.
         def compile
-          if File.exist?(lockfile)
-            info("Installing cookbooks for Policyfile #{policyfile} using `#{cli_path} install`")
+          if File.exist?(lockfile) && always_update
+            info("Policy lock file exists and always_update is set, running `#{cli_path} update` for Policyfile #{policyfile}...")
+            run_command("chef update #{escape_path(policyfile)}")
           else
             info("Policy lock file doesn't exist, running `#{cli_path} install` for Policyfile #{policyfile}...")
-          end
-          run_command("#{cli_path} install #{escape_path(policyfile)} --chef-license #{license}")
-
-          if always_update
-            info("Updating policy lock using `#{cli_path} update`")
-            run_command("#{cli_path} update #{escape_path(policyfile)} --chef-license #{license}")
+            run_command("chef install #{escape_path(policyfile)}")
+            if always_update
+              info("Updating policy lock using `#{cli_path} update`")
+              run_command("chef update #{escape_path(policyfile)}")
+            end
           end
         end
 


### PR DESCRIPTION
Right now if you specify `always_update` in your kitchen.yml - If the policyfile lock is incorrect such that the command `chef install` fails, the kitchen tests will fail.

Instead it you are specifying `always_update` is should just run the `chef update` command which behind the scenes also does a [`chef install`](https://github.com/chef/chef-cli/blob/main/lib/chef-cli/command/update.rb#L102-L104).

This also makes it faster, currently it is doing `chef install` then running `chef update` which also calls install

Signed-off-by: Nick Smith <clickthisnick@users.noreply.github.com>